### PR TITLE
fix rehash command not found.

### DIFF
--- a/shell/pinyin-comp.zsh
+++ b/shell/pinyin-comp.zsh
@@ -1,5 +1,10 @@
 
 # use pinyin-comp to perform completion based upon pinyin acronym
+function _force_rehash() {
+  (( CURRENT == 1 )) && rehash
+  return 1
+}
+
 function _pinyin_comp()
 {
     # chsdir print one candidate per line


### PR DESCRIPTION
In ubuntu 16.04 there is a "_force_rehash command not found" error, by reading "https://github.com/caarlos0/dotfiles/blob/master/zsh/completion.zsh" I add this function.
